### PR TITLE
Remove blueprint-compiler

### DIFF
--- a/im.bernard.Memorado.json
+++ b/im.bernard.Memorado.json
@@ -22,18 +22,6 @@
         "*.a"
     ],
     "modules" : [
-    	{
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": ["*"],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-                    "tag": "v0.18.0"
-                }
-            ]
-        },
         {
             "name" : "memorado",
             "buildsystem" : "meson",


### PR DESCRIPTION
`blueprint-compiler` is in the SDK now and can be removed.